### PR TITLE
Add (failing) test for markdown references that would not be in the same chunk

### DIFF
--- a/__tests__/fixtures/large_document_test.md
+++ b/__tests__/fixtures/large_document_test.md
@@ -1,0 +1,1502 @@
+Hello [link][1]
+
+
+This test is to demonstrate that a link may be separated by its definition by any arbitrary amount of content.
+
+
+The below is an excerpt of Charles Dickens' **A Christmas Carol**, from Project Gutenberg (Public Domain text).
+
+
+MARLEY'S GHOST
+
+
+Marley was dead, to begin with. There is no doubt whatever about that.
+The register of his burial was signed by the clergyman, the clerk, the
+undertaker, and the chief mourner. Scrooge signed it. And Scrooge's name
+was good upon 'Change for anything he chose to put his hand to. Old
+Marley was as dead as a door-nail.
+
+Mind! I don't mean to say that I know of my own knowledge, what there is
+particularly dead about a door-nail. I might have been inclined, myself,
+to regard a coffin-nail as the deadest piece of ironmongery in the
+trade. But the wisdom of our ancestors is in the simile; and my
+unhallowed hands shall not disturb it, or the country's done for. You
+will, therefore, permit me to repeat, emphatically, that Marley was as
+dead as a door-nail.
+
+Scrooge knew he was dead? Of course he did. How could it be otherwise?
+Scrooge and he were partners for I don't know how many years. Scrooge
+was his sole executor, his sole administrator, his sole assign, his sole
+residuary legatee, his sole friend, and sole mourner. And even Scrooge
+was not so dreadfully cut up by the sad event but that he was an
+excellent man of business on the very day of the funeral, and solemnised
+it with an undoubted bargain.
+
+The mention of Marley's funeral brings me back to the point I started
+from. There is no doubt that Marley was dead. This must be distinctly
+understood, or nothing wonderful can come of the story I am going to
+relate. If we were not perfectly convinced that Hamlet's father died
+before the play began, there would be nothing more remarkable in his
+taking a stroll at night, in an easterly wind, upon his own ramparts,
+than there would be in any other middle-aged gentleman rashly turning
+out after dark in a breezy spot--say St. Paul's Churchyard, for
+instance--literally to astonish his son's weak mind.
+
+Scrooge never painted out Old Marley's name. There it stood, years
+afterwards, above the warehouse door: Scrooge and Marley. The firm was
+known as Scrooge and Marley. Sometimes people new to the business called
+Scrooge Scrooge, and sometimes Marley, but he answered to both names. It
+was all the same to him.
+
+Oh! but he was a tight-fisted hand at the grindstone, Scrooge! a
+squeezing, wrenching, grasping, scraping, clutching, covetous old
+sinner! Hard and sharp as flint, from which no steel had ever struck out
+generous fire; secret, and self-contained, and solitary as an oyster.
+The cold within him froze his old features, nipped his pointed nose,
+shrivelled his cheek, stiffened his gait; made his eyes red, his thin
+lips blue; and spoke out shrewdly in his grating voice. A frosty rime
+was on his head, and on his eyebrows, and his wiry chin. He carried his
+own low temperature always about with him; he iced his office in the
+dog-days, and didn't thaw it one degree at Christmas.
+
+External heat and cold had little influence on Scrooge. No warmth could
+warm, no wintry weather chill him. No wind that blew was bitterer than
+he, no falling snow was more intent upon its purpose, no pelting rain
+less open to entreaty. Foul weather didn't know where to have him. The
+heaviest rain, and snow, and hail, and sleet could boast of the
+advantage over him in only one respect. They often 'came down'
+handsomely, and Scrooge never did.
+
+Nobody ever stopped him in the street to say, with gladsome looks, 'My
+dear Scrooge, how are you? When will you come to see me?' No beggars
+implored him to bestow a trifle, no children asked him what it was
+o'clock, no man or woman ever once in all his life inquired the way to
+such and such a place, of Scrooge. Even the blind men's dogs appeared to
+know him; and, when they saw him coming on, would tug their owners into
+doorways and up courts; and then would wag their tails as though they
+said, 'No eye at all is better than an evil eye, dark master!'
+
+But what did Scrooge care? It was the very thing he liked. To edge his
+way along the crowded paths of life, warning all human sympathy to keep
+its distance, was what the knowing ones call 'nuts' to Scrooge.
+
+Once upon a time--of all the good days in the year, on Christmas
+Eve--old Scrooge sat busy in his counting-house. It was cold, bleak,
+biting weather; foggy withal; and he could hear the people in the court
+outside go wheezing up and down, beating their hands upon their breasts,
+and stamping their feet upon the pavement stones to warm them. The City
+clocks had only just gone three, but it was quite dark already--it had
+not been light all day--and candles were flaring in the windows of the
+neighbouring offices, like ruddy smears upon the palpable brown air. The
+fog came pouring in at every chink and keyhole, and was so dense
+without, that, although the court was of the narrowest, the houses
+opposite were mere phantoms. To see the dingy cloud come drooping down,
+obscuring everything, one might have thought that nature lived hard by,
+and was brewing on a large scale.
+
+The door of Scrooge's counting-house was open, that he might keep his
+eye upon his clerk, who in a dismal little cell beyond, a sort of tank,
+was copying letters. Scrooge had a very small fire, but the clerk's fire
+was so very much smaller that it looked like one coal. But he couldn't
+replenish it, for Scrooge kept the coal-box in his own room; and so
+surely as the clerk came in with the shovel, the master predicted that
+it would be necessary for them to part. Wherefore the clerk put on his
+white comforter, and tried to warm himself at the candle; in which
+effort, not being a man of strong imagination, he failed.
+
+'A merry Christmas, uncle! God save you!' cried a cheerful voice. It was
+the voice of Scrooge's nephew, who came upon him so quickly that this
+was the first intimation he had of his approach.
+
+'Bah!' said Scrooge. 'Humbug!'
+
+He had so heated himself with rapid walking in the fog and frost, this
+nephew of Scrooge's, that he was all in a glow; his face was ruddy and
+handsome; his eyes sparkled, and his breath smoked again.
+
+'Christmas a humbug, uncle!' said Scrooge's nephew. 'You don't mean
+that, I am sure?'
+
+'I do,' said Scrooge. 'Merry Christmas! What right have you to be merry?
+What reason have you to be merry? You're poor enough.'
+
+'Come, then,' returned the nephew gaily. 'What right have you to be
+dismal? What reason have you to be morose? You're rich enough.'
+
+Scrooge, having no better answer ready on the spur of the moment, said,
+'Bah!' again; and followed it up with 'Humbug!'
+
+'Don't be cross, uncle!' said the nephew.
+
+'What else can I be,' returned the uncle, 'when I live in such a world
+of fools as this? Merry Christmas! Out upon merry Christmas! What's
+Christmas-time to you but a time for paying bills without money; a time
+for finding yourself a year older, and not an hour richer; a time for
+balancing your books, and having every item in 'em through a round dozen
+of months presented dead against you? If I could work my will,' said
+Scrooge indignantly, 'every idiot who goes about with "Merry Christmas"
+on his lips should be boiled with his own pudding, and buried with a
+stake of holly through his heart. He should!'
+
+'Uncle!' pleaded the nephew.
+
+'Nephew!' returned the uncle sternly, 'keep Christmas in your own way,
+and let me keep it in mine.'
+
+'Keep it!' repeated Scrooge's nephew. 'But you don't keep it.'
+
+'Let me leave it alone, then,' said Scrooge. 'Much good may it do you!
+Much good it has ever done you!'
+
+'There are many things from which I might have derived good, by which I
+have not profited, I dare say,' returned the nephew; 'Christmas among
+the rest. But I am sure I have always thought of Christmas-time, when
+it has come round--apart from the veneration due to its sacred name and
+origin, if anything belonging to it can be apart from that--as a good
+time; a kind, forgiving, charitable, pleasant time; the only time I know
+of, in the long calendar of the year, when men and women seem by one
+consent to open their shut-up hearts freely, and to think of people
+below them as if they really were fellow-passengers to the grave, and
+not another race of creatures bound on other journeys. And therefore,
+uncle, though it has never put a scrap of gold or silver in my pocket, I
+believe that it _has_ done me good and _will_ do me good; and I say, God
+bless it!'
+
+The clerk in the tank involuntarily applauded. Becoming immediately
+sensible of the impropriety, he poked the fire, and extinguished the
+last frail spark for ever.
+
+'Let me hear another sound from _you_,' said Scrooge, 'and you'll keep
+your Christmas by losing your situation! You're quite a powerful
+speaker, sir,' he added, turning to his nephew. 'I wonder you don't go
+into Parliament.'
+
+'Don't be angry, uncle. Come! Dine with us to-morrow.'
+
+Scrooge said that he would see him----Yes, indeed he did. He went the
+whole length of the expression, and said that he would see him in that
+extremity first.
+
+'But why?' cried Scrooge's nephew. 'Why?'
+
+'Why did you get married?' said Scrooge.
+
+'Because I fell in love.'
+
+'Because you fell in love!' growled Scrooge, as if that were the only
+one thing in the world more ridiculous than a merry Christmas. 'Good
+afternoon!'
+
+'Nay, uncle, but you never came to see me before that happened. Why give
+it as a reason for not coming now?'
+
+'Good afternoon,' said Scrooge.
+
+'I want nothing from you; I ask nothing of you; why cannot we be
+friends?'
+
+'Good afternoon!' said Scrooge.
+
+'I am sorry, with all my heart, to find you so resolute. We have never
+had any quarrel to which I have been a party. But I have made the trial
+in homage to Christmas, and I'll keep my Christmas humour to the last.
+So A Merry Christmas, uncle!'
+
+'Good afternoon,' said Scrooge.
+
+'And A Happy New Year!'
+
+'Good afternoon!' said Scrooge.
+
+His nephew left the room without an angry word, notwithstanding. He
+stopped at the outer door to bestow the greetings of the season on the
+clerk, who, cold as he was, was warmer than Scrooge; for he returned
+them cordially.
+
+'There's another fellow,' muttered Scrooge, who overheard him: 'my
+clerk, with fifteen shillings a week, and a wife and family, talking
+about a merry Christmas. I'll retire to Bedlam.'
+
+This lunatic, in letting Scrooge's nephew out, had let two other people
+in. They were portly gentlemen, pleasant to behold, and now stood, with
+their hats off, in Scrooge's office. They had books and papers in their
+hands, and bowed to him.
+
+'Scrooge and Marley's, I believe,' said one of the gentlemen, referring
+to his list. 'Have I the pleasure of addressing Mr. Scrooge, or Mr.
+Marley?'
+
+'Mr. Marley has been dead these seven years,' Scrooge replied. 'He died
+seven years ago, this very night.'
+
+'We have no doubt his liberality is well represented by his surviving
+partner,' said the gentleman, presenting his credentials.
+
+It certainly was; for they had been two kindred spirits. At the ominous
+word 'liberality' Scrooge frowned, and shook his head, and handed the
+credentials back.
+
+'At this festive season of the year, Mr. Scrooge,' said the gentleman,
+taking up a pen, 'it is more than usually desirable that we should make
+some slight provision for the poor and destitute, who suffer greatly at
+the present time. Many thousands are in want of common necessaries;
+hundreds of thousands are in want of common comforts, sir.'
+
+'Are there no prisons?' asked Scrooge.
+
+'Plenty of prisons,' said the gentleman, laying down the pen again.
+
+'And the Union workhouses?' demanded Scrooge. 'Are they still in
+operation?'
+
+'They are. Still,' returned the gentleman, 'I wish I could say they were
+not.'
+
+'The Treadmill and the Poor Law are in full vigour, then?' said Scrooge.
+
+'Both very busy, sir.'
+
+'Oh! I was afraid, from what you said at first, that something had
+occurred to stop them in their useful course,' said Scrooge. 'I am very
+glad to hear it.'
+
+'Under the impression that they scarcely furnish Christian cheer of mind
+or body to the multitude,' returned the gentleman, 'a few of us are
+endeavouring to raise a fund to buy the Poor some meat and drink, and
+means of warmth. We choose this time, because it is a time, of all
+others, when Want is keenly felt, and Abundance rejoices. What shall I
+put you down for?'
+
+'Nothing!' Scrooge replied.
+
+'You wish to be anonymous?'
+
+'I wish to be left alone,' said Scrooge. 'Since you ask me what I wish,
+gentlemen, that is my answer. I don't make merry myself at Christmas,
+and I can't afford to make idle people merry. I help to support the
+establishments I have mentioned--they cost enough: and those who are
+badly off must go there.'
+
+'Many can't go there; and many would rather die.'
+
+'If they would rather die,' said Scrooge, 'they had better do it, and
+decrease the surplus population. Besides--excuse me--I don't know that.'
+
+'But you might know it,' observed the gentleman.
+
+'It's not my business,' Scrooge returned. 'It's enough for a man to
+understand his own business, and not to interfere with other people's.
+Mine occupies me constantly. Good afternoon, gentlemen!'
+
+Seeing clearly that it would be useless to pursue their point, the
+gentlemen withdrew. Scrooge resumed his labours with an improved opinion
+of himself, and in a more facetious temper than was usual with him.
+
+Meanwhile the fog and darkness thickened so, that people ran about with
+flaring links, proffering their services to go before horses in
+carriages, and conduct them on their way. The ancient tower of a church,
+whose gruff old bell was always peeping slyly down at Scrooge out of a
+Gothic window in the wall, became invisible, and struck the hours and
+quarters in the clouds, with tremulous vibrations afterwards, as if its
+teeth were chattering in its frozen head up there. The cold became
+intense. In the main street, at the corner of the court, some labourers
+were repairing the gas-pipes, and had lighted a great fire in a brazier,
+round which a party of ragged men and boys were gathered: warming their
+hands and winking their eyes before the blaze in rapture. The water-plug
+being left in solitude, its overflowings suddenly congealed, and turned
+to misanthropic ice. The brightness of the shops, where holly sprigs and
+berries crackled in the lamp heat of the windows, made pale faces ruddy
+as they passed. Poulterers' and grocers' trades became a splendid joke:
+a glorious pageant, with which it was next to impossible to believe that
+such dull principles as bargain and sale had anything to do. The Lord
+Mayor, in the stronghold of the mighty Mansion House, gave orders to his
+fifty cooks and butlers to keep Christmas as a Lord Mayor's household
+should; and even the little tailor, whom he had fined five shillings on
+the previous Monday for being drunk and bloodthirsty in the streets,
+stirred up to-morrow's pudding in his garret, while his lean wife and
+the baby sallied out to buy the beef.
+
+Foggier yet, and colder! Piercing, searching, biting cold. If the good
+St. Dunstan had but nipped the Evil Spirit's nose with a touch of such
+weather as that, instead of using his familiar weapons, then indeed he
+would have roared to lusty purpose. The owner of one scant young nose,
+gnawed and mumbled by the hungry cold as bones are gnawed by dogs,
+stooped down at Scrooge's keyhole to regale him with a Christmas carol;
+but, at the first sound of
+
+  'God bless you, merry gentleman,
+  May nothing you dismay!'
+
+Scrooge seized the ruler with such energy of action that the singer fled
+in terror, leaving the keyhole to the fog, and even more congenial
+frost.
+
+At length the hour of shutting up the counting-house arrived. With an
+ill-will Scrooge dismounted from his stool, and tacitly admitted the
+fact to the expectant clerk in the tank, who instantly snuffed his
+candle out, and put on his hat.
+
+'You'll want all day to-morrow, I suppose?' said Scrooge.
+
+'If quite convenient, sir.'
+
+'It's not convenient,' said Scrooge, 'and it's not fair. If I was to
+stop half-a-crown for it, you'd think yourself ill used, I'll be bound?'
+
+The clerk smiled faintly.
+
+'And yet,' said Scrooge, 'you don't think _me_ ill used when I pay a
+day's wages for no work.'
+
+
+The clerk observed that it was only once a year.
+
+'A poor excuse for picking a man's pocket every twenty-fifth of
+December!' said Scrooge, buttoning his greatcoat to the chin. 'But I
+suppose you must have the whole day. Be here all the earlier next
+morning.'
+
+The clerk promised that he would; and Scrooge walked out with a growl.
+The office was closed in a twinkling, and the clerk, with the long ends
+of his white comforter dangling below his waist (for he boasted no
+greatcoat), went down a slide on Cornhill, at the end of a lane of boys,
+twenty times, in honour of its being Christmas Eve, and then ran home to
+Camden Town as hard as he could pelt, to play at blind man's-buff.
+
+Scrooge took his melancholy dinner in his usual melancholy tavern; and
+having read all the newspapers, and beguiled the rest of the evening
+with his banker's book, went home to bed. He lived in chambers which had
+once belonged to his deceased partner. They were a gloomy suite of
+rooms, in a lowering pile of building up a yard, where it had so little
+business to be, that one could scarcely help fancying it must have run
+there when it was a young house, playing at hide-and-seek with other
+houses, and have forgotten the way out again. It was old enough now, and
+dreary enough; for nobody lived in it but Scrooge, the other rooms
+being all let out as offices. The yard was so dark that even Scrooge,
+who knew its every stone, was fain to grope with his hands. The fog and
+frost so hung about the black old gateway of the house, that it seemed
+as if the Genius of the Weather sat in mournful meditation on the
+threshold.
+
+Now, it is a fact that there was nothing at all particular about the
+knocker on the door, except that it was very large. It is also a fact
+that Scrooge had seen it, night and morning, during his whole residence
+in that place; also that Scrooge had as little of what is called fancy
+about him as any man in the City of London, even including--which is a
+bold word--the corporation, aldermen, and livery. Let it also be borne
+in mind that Scrooge had not bestowed one thought on Marley since his
+last mention of his seven-years'-dead partner that afternoon. And then
+let any man explain to me, if he can, how it happened that Scrooge,
+having his key in the lock of the door, saw in the knocker, without its
+undergoing any intermediate process of change--not a knocker, but
+Marley's face.
+
+Marley's face. It was not in impenetrable shadow, as the other objects
+in the yard were, but had a dismal light about it, like a bad lobster in
+a dark cellar. It was not angry or ferocious, but looked at Scrooge as
+Marley used to look; with ghostly spectacles turned up on its ghostly
+forehead. The hair was curiously stirred, as if by breath or hot air;
+and, though the eyes were wide open, they were perfectly motionless.
+That, and its livid colour, made it horrible; but its horror seemed to
+be in spite of the face, and beyond its control, rather than a part of
+its own expression.
+
+As Scrooge looked fixedly at this phenomenon, it was a knocker again.
+
+To say that he was not startled, or that his blood was not conscious of
+a terrible sensation to which it had been a stranger from infancy, would
+be untrue. But he put his hand upon the key he had relinquished, turned
+it sturdily, walked in, and lighted his candle.
+
+He _did_ pause, with a moment's irresolution, before he shut the door;
+and he _did_ look cautiously behind it first, as if he half expected to
+be terrified with the sight of Marley's pigtail sticking out into the
+hall. But there was nothing on the back of the door, except the screws
+and nuts that held the knocker on, so he said, 'Pooh, pooh!' and closed
+it with a bang.
+
+The sound resounded through the house like thunder. Every room above,
+and every cask in the wine-merchant's cellars below, appeared to have a
+separate peal of echoes of its own. Scrooge was not a man to be
+frightened by echoes. He fastened the door, and walked across the hall,
+and up the stairs: slowly, too: trimming his candle as he went.
+
+You may talk vaguely about driving a coach and six up a good old flight
+of stairs, or through a bad young Act of Parliament; but I mean to say
+you might have got a hearse up that staircase, and taken it broadwise,
+with the splinter-bar towards the wall, and the door towards the
+balustrades: and done it easy. There was plenty of width for that, and
+room to spare; which is perhaps the reason why Scrooge thought he saw a
+locomotive hearse going on before him in the gloom. Half-a-dozen
+gas-lamps out of the street wouldn't have lighted the entry too well, so
+you may suppose that it was pretty dark with Scrooge's dip.
+
+Up Scrooge went, not caring a button for that. Darkness is cheap, and
+Scrooge liked it. But, before he shut his heavy door, he walked through
+his rooms to see that all was right. He had just enough recollection of
+the face to desire to do that.
+
+Sitting-room, bedroom, lumber-room. All as they should be. Nobody under
+the table, nobody under the sofa; a small fire in the grate; spoon and
+basin ready; and the little saucepan of gruel (Scrooge had a cold in his
+head) upon the hob. Nobody under the bed; nobody in the closet; nobody
+in his dressing-gown, which was hanging up in a suspicious attitude
+against the wall. Lumber-room as usual. Old fire-guard, old shoes, two
+fish baskets, washing-stand on three legs, and a poker.
+
+
+Quite satisfied, he closed his door, and locked himself in; double
+locked himself in, which was not his custom. Thus secured against
+surprise, he took off his cravat; put on his dressing-gown and slippers,
+and his nightcap; and sat down before the fire to take his gruel.
+
+It was a very low fire indeed; nothing on such a bitter night. He was
+obliged to sit close to it, and brood over it, before he could extract
+the least sensation of warmth from such a handful of fuel. The fireplace
+was an old one, built by some Dutch merchant long ago, and paved all
+round with quaint Dutch tiles, designed to illustrate the Scriptures.
+There were Cains and Abels, Pharaoh's daughters, Queens of Sheba,
+Angelic messengers descending through the air on clouds like
+feather-beds, Abrahams, Belshazzars, Apostles putting off to sea in
+butter-boats, hundreds of figures to attract his thoughts; and yet that
+face of Marley, seven years dead, came like the ancient Prophet's rod,
+and swallowed up the whole. If each smooth tile had been a blank at
+first, with power to shape some picture on its surface from the
+disjointed fragments of his thoughts, there would have been a copy of
+old Marley's head on every one.
+
+'Humbug!' said Scrooge; and walked across the room.
+
+After several turns he sat down again. As he threw his head back in the
+chair, his glance happened to rest upon a bell, a disused bell, that
+hung in the room, and communicated, for some purpose now forgotten, with
+a chamber in the highest storey of the building. It was with great
+astonishment, and with a strange, inexplicable dread, that, as he
+looked, he saw this bell begin to swing. It swung so softly in the
+outset that it scarcely made a sound; but soon it rang out loudly, and
+so did every bell in the house.
+
+This might have lasted half a minute, or a minute, but it seemed an
+hour. The bells ceased, as they had begun, together. They were succeeded
+by a clanking noise deep down below as if some person were dragging a
+heavy chain over the casks in the wine-merchant's cellar. Scrooge then
+remembered to have heard that ghosts in haunted houses were described as
+dragging chains.
+
+The cellar door flew open with a booming sound, and then he heard the
+noise much louder on the floors below; then coming up the stairs; then
+coming straight towards his door.
+
+'It's humbug still!' said Scrooge. 'I won't believe it.'
+
+His colour changed, though, when, without a pause, it came on through
+the heavy door and passed into the room before his eyes. Upon its coming
+in, the dying flame leaped up, as though it cried, 'I know him! Marley's
+Ghost!' and fell again.
+
+The same face: the very same. Marley in his pigtail, usual waistcoat,
+tights, and boots; the tassels on the latter bristling, like his
+pigtail, and his coat-skirts, and the hair upon his head. The chain he
+drew was clasped about his middle. It was long, and wound about him like
+a tail; and it was made (for Scrooge observed it closely) of cash-boxes,
+keys, padlocks, ledgers, deeds, and heavy purses wrought in steel. His
+body was transparent: so that Scrooge, observing him, and looking
+through his waistcoat, could see the two buttons on his coat behind.
+
+Scrooge had often heard it said that Marley had no bowels, but he had
+never believed it until now.
+
+No, nor did he believe it even now. Though he looked the phantom through
+and through, and saw it standing before him; though he felt the chilling
+influence of its death-cold eyes, and marked the very texture of the
+folded kerchief bound about its head and chin, which wrapper he had not
+observed before, he was still incredulous, and fought against his
+senses.
+
+'How now!' said Scrooge, caustic and cold as ever. 'What do you want
+with me?'
+
+'Much!'--Marley's voice; no doubt about it.
+
+'Who are you?'
+
+'Ask me who I _was_.'
+
+'Who _were_ you, then?' said Scrooge, raising his voice. 'You're
+particular, for a shade.' He was going to say '_to_ a shade,' but
+substituted this, as more appropriate.
+
+'In life I was your partner, Jacob Marley.'
+
+'Can you--can you sit down?' asked Scrooge, looking doubtfully at him.
+
+'I can.'
+
+'Do it, then.'
+
+Scrooge asked the question, because he didn't know whether a ghost so
+transparent might find himself in a condition to take a chair; and felt
+that in the event of its being impossible, it might involve the
+necessity of an embarrassing explanation. But the Ghost sat down on the
+opposite side of the fireplace, as if he were quite used to it.
+
+'You don't believe in me,' observed the Ghost.
+
+'I don't,' said Scrooge.
+
+'What evidence would you have of my reality beyond that of your own
+senses?'
+
+'I don't know,' said Scrooge.
+
+'Why do you doubt your senses?'
+
+'Because,' said Scrooge, 'a little thing affects them. A slight disorder
+of the stomach makes them cheats. You may be an undigested bit of beef,
+a blot of mustard, a crumb of cheese, a fragment of an underdone potato.
+There's more of gravy than of grave about you, whatever you are!'
+
+Scrooge was not much in the habit of cracking jokes, nor did he feel in
+his heart by any means waggish then. The truth is, that he tried to be
+smart, as a means of distracting his own attention, and keeping down his
+terror; for the spectre's voice disturbed the very marrow in his bones.
+
+To sit staring at those fixed, glazed eyes in silence, for a moment,
+would play, Scrooge felt, the very deuce with him. There was something
+very awful, too, in the spectre's being provided with an infernal
+atmosphere of his own. Scrooge could not feel it himself, but this was
+clearly the case; for though the Ghost sat perfectly motionless, its
+hair, and skirts, and tassels were still agitated as by the hot vapour
+from an oven.
+
+'You see this toothpick?' said Scrooge, returning quickly to the charge,
+for the reason just assigned; and wishing, though it were only for a
+second, to divert the vision's stony gaze from himself.
+
+'I do,' replied the Ghost.
+
+'You are not looking at it,' said Scrooge.
+
+'But I see it,' said the Ghost, 'notwithstanding.'
+
+'Well!' returned Scrooge, 'I have but to swallow this, and be for the
+rest of my days persecuted by a legion of goblins, all of my own
+creation. Humbug, I tell you: humbug!'
+
+At this the spirit raised a frightful cry, and shook its chain with such
+a dismal and appalling noise, that Scrooge held on tight to his chair,
+to save himself from falling in a swoon. But how much greater was his
+horror when the phantom, taking off the bandage round his head, as if it
+were too warm to wear indoors, its lower jaw dropped down upon its
+breast!
+
+Scrooge fell upon his knees, and clasped his hands before his face.
+
+'Mercy!' he said. 'Dreadful apparition, why do you trouble me?'
+
+'Man of the worldly mind!' replied the Ghost, 'do you believe in me or
+not?'
+
+'I do,' said Scrooge; 'I must. But why do spirits walk the earth, and
+why do they come to me?'
+
+'It is required of every man,' the Ghost returned, 'that the spirit
+within him should walk abroad among his fellow-men, and travel far and
+wide; and, if that spirit goes not forth in life, it is condemned to do
+so after death. It is doomed to wander through the world--oh, woe is
+me!--and witness what it cannot share, but might have shared on earth,
+and turned to happiness!'
+
+Again the spectre raised a cry, and shook its chain and wrung its
+shadowy hands.
+
+'You are fettered,' said Scrooge, trembling. 'Tell me why?'
+
+'I wear the chain I forged in life,' replied the Ghost. 'I made it link
+by link, and yard by yard; I girded it on of my own free will, and of
+my own free will I wore it. Is its pattern strange to _you_?'
+
+Scrooge trembled more and more.
+
+'Or would you know,' pursued the Ghost, 'the weight and length of the
+strong coil you bear yourself? It was full as heavy and as long as this
+seven Christmas Eves ago. You have laboured on it since. It is a
+ponderous chain!'
+
+Scrooge glanced about him on the floor, in the expectation of finding
+himself surrounded by some fifty or sixty fathoms of iron cable; but he
+could see nothing.
+
+'Jacob!' he said imploringly. 'Old Jacob Marley, tell me more! Speak
+comfort to me, Jacob!'
+
+'I have none to give,' the Ghost replied. 'It comes from other regions,
+Ebenezer Scrooge, and is conveyed by other ministers, to other kinds of
+men. Nor can I tell you what I would. A very little more is all
+permitted to me. I cannot rest, I cannot stay, I cannot linger anywhere.
+My spirit never walked beyond our counting-house--mark me;--in life my
+spirit never roved beyond the narrow limits of our money-changing hole;
+and weary journeys lie before me!'
+
+It was a habit with Scrooge, whenever he became thoughtful, to put his
+hands in his breeches pockets. Pondering on what the Ghost had said, he
+did so now, but without lifting up his eyes, or getting off his knees.
+
+
+'You must have been very slow about it, Jacob,' Scrooge observed in a
+business-like manner, though with humility and deference.
+
+'Slow!' the Ghost repeated.
+
+'Seven years dead,' mused Scrooge. 'And travelling all the time?'
+
+'The whole time,' said the Ghost. 'No rest, no peace. Incessant torture
+of remorse.'
+
+'You travel fast?' said Scrooge.
+
+
+'On the wings of the wind,' replied the Ghost.
+
+'You might have got over a great quantity of ground in seven years,'
+said Scrooge.
+
+The Ghost, on hearing this, set up another cry, and clanked its chain so
+hideously in the dead silence of the night, that the Ward would have
+been justified in indicting it for a nuisance.
+
+'Oh! captive, bound, and double-ironed,' cried the phantom, 'not to know
+that ages of incessant labour, by immortal creatures, for this earth
+must pass into eternity before the good of which it is susceptible is
+all developed! Not to know that any Christian spirit working kindly in
+its little sphere, whatever it may be, will find its mortal life too
+short for its vast means of usefulness! Not to know that no space of
+regret can make amends for one life's opportunities misused! Yet such
+was I! Oh, such was I!'
+
+'But you were always a good man of business, Jacob,' faltered Scrooge,
+who now began to apply this to himself.
+
+'Business!' cried the Ghost, wringing its hands again. 'Mankind was my
+business. The common welfare was my business; charity, mercy,
+forbearance, and benevolence were, all, my business. The dealings of my
+trade were but a drop of water in the comprehensive ocean of my
+business!'
+
+It held up its chain at arm's-length, as if that were the cause of all
+its unavailing grief, and flung it heavily upon the ground again.
+
+'At this time of the rolling year,' the spectre said, 'I suffer most.
+Why did I walk through crowds of fellow-beings with my eyes turned down,
+and never raise them to that blessed Star which led the Wise Men to a
+poor abode? Were there no poor homes to which its light would have
+conducted _me_?'
+
+Scrooge was very much dismayed to hear the spectre going on at this
+rate, and began to quake exceedingly.
+
+'Hear me!' cried the Ghost. 'My time is nearly gone.'
+
+'I will,' said Scrooge. 'But don't be hard upon me! Don't be flowery,
+Jacob! Pray!'
+
+'How it is that I appear before you in a shape that you can see, I may
+not tell. I have sat invisible beside you many and many a day.'
+
+It was not an agreeable idea. Scrooge shivered, and wiped the
+perspiration from his brow.
+
+'That is no light part of my penance,' pursued the Ghost. 'I am here
+to-night to warn you that you have yet a chance and hope of escaping my
+fate. A chance and hope of my procuring, Ebenezer.'
+
+'You were always a good friend to me,' said Scrooge. 'Thankee!'
+
+'You will be haunted,' resumed the Ghost, 'by Three Spirits.'
+
+Scrooge's countenance fell almost as low as the Ghost's had done.
+
+'Is that the chance and hope you mentioned, Jacob?' he demanded in a
+faltering voice.
+
+'It is.'
+
+'I--I think I'd rather not,' said Scrooge.
+
+'Without their visits,' said the Ghost, 'you cannot hope to shun the
+path I tread. Expect the first to-morrow when the bell tolls One.'
+
+'Couldn't I take 'em all at once, and have it over, Jacob?' hinted
+Scrooge.
+
+'Expect the second on the next night at the same hour. The third, upon
+the next night when the last stroke of Twelve has ceased to vibrate.
+Look to see me no more; and look that, for your own sake, you remember
+what has passed between us!'
+
+When it had said these words, the spectre took its wrapper from the
+table, and bound it round its head as before. Scrooge knew this by the
+smart sound its teeth made when the jaws were brought together by the
+bandage. He ventured to raise his eyes again, and found his supernatural
+visitor confronting him in an erect attitude, with its chain wound over
+and about its arm.
+
+The apparition walked backward from him; and, at every step it took, the
+window raised itself a little, so that, when the spectre reached it, it
+was wide open. It beckoned Scrooge to approach, which he did. When they
+were within two paces of each other, Marley's Ghost held up its hand,
+warning him to come no nearer. Scrooge stopped.
+
+Not so much in obedience as in surprise and fear; for, on the raising of
+the hand, he became sensible of confused noises in the air; incoherent
+sounds of lamentation and regret; wailings inexpressibly sorrowful and
+self-accusatory. The spectre, after listening for a moment, joined in
+the mournful dirge; and floated out upon the bleak, dark night.
+
+Scrooge followed to the window: desperate in his curiosity. He looked
+out.
+
+The air was filled with phantoms, wandering hither and thither in
+restless haste, and moaning as they went. Every one of them wore chains
+like Marley's Ghost; some few (they might be guilty governments) were
+linked together; none were free. Many had been personally known to
+Scrooge in their lives. He had been quite familiar with one old ghost in
+a white waistcoat, with a monstrous iron safe attached to its ankle, who
+cried piteously at being unable to assist a wretched woman with an
+infant, whom it saw below upon a doorstep. The misery with them all was
+clearly, that they sought to interfere, for good, in human matters, and
+had lost the power for ever.
+
+Whether these creatures faded into mist, or mist enshrouded them, he
+could not tell. But they and their spirit voices faded together; and
+the night became as it had been when he walked home.
+
+Scrooge closed the window, and examined the door by which the Ghost had
+entered. It was double locked, as he had locked it with his own hands,
+and the bolts were undisturbed. He tried to say 'Humbug!' but stopped at
+the first syllable. And being, from the emotions he had undergone, or
+the fatigues of the day, or his glimpse of the Invisible World, or the
+dull conversation of the Ghost, or the lateness of the hour, much in
+need of repose, went straight to bed without undressing, and fell asleep
+upon the instant.
+
+
+
+STAVE TWO
+
+
+
+
+
+THE FIRST OF THE THREE SPIRITS
+
+
+When Scrooge awoke it was so dark, that, looking out of bed, he could
+scarcely distinguish the transparent window from the opaque walls of his
+chamber. He was endeavouring to pierce the darkness with his ferret
+eyes, when the chimes of a neighbouring church struck the four quarters.
+So he listened for the hour.
+
+To his great astonishment, the heavy bell went on from six to seven, and
+from seven to eight, and regularly up to twelve; then stopped. Twelve!
+It was past two when he went to bed. The clock was wrong. An icicle must
+have got into the works. Twelve!
+
+He touched the spring of his repeater, to correct this most preposterous
+clock. Its rapid little pulse beat twelve, and stopped.
+
+'Why, it isn't possible,' said Scrooge, 'that I can have slept through a
+whole day and far into another night. It isn't possible that anything
+has happened to the sun, and this is twelve at noon!'
+
+The idea being an alarming one, he scrambled out of bed, and groped his
+way to the window. He was obliged to rub the frost off with the sleeve
+of his dressing-gown before he could see anything; and could see very
+little then. All he could make out was, that it was still very foggy and
+extremely cold, and that there was no noise of people running to and
+fro, and making a great stir, as there unquestionably would have been if
+night had beaten off bright day, and taken possession of the world. This
+was a great relief, because 'Three days after sight of this First of
+Exchange pay to Mr. Ebenezer Scrooge or his order,' and so forth, would
+have become a mere United States security if there were no days to count
+by.
+
+Scrooge went to bed again, and thought, and thought, and thought it over
+and over, and could make nothing of it. The more he thought, the more
+perplexed he was; and, the more he endeavoured not to think, the more he
+thought.
+
+Marley's Ghost bothered him exceedingly. Every time he resolved within
+himself, after mature inquiry that it was all a dream, his mind flew
+back again, like a strong spring released, to its first position, and
+presented the same problem to be worked all through, 'Was it a dream or
+not?'
+
+Scrooge lay in this state until the chime had gone three-quarters more,
+when he remembered, on a sudden, that the Ghost had warned him of a
+visitation when the bell tolled one. He resolved to lie awake until the
+hour was passed; and, considering that he could no more go to sleep than
+go to heaven, this was, perhaps, the wisest resolution in his power.
+
+The quarter was so long, that he was more than once convinced he must
+have sunk into a doze unconsciously, and missed the clock. At length it
+broke upon his listening ear.
+
+'Ding, dong!'
+
+'A quarter past,' said Scrooge, counting.
+
+'Ding, dong!'
+
+'Half past,' said Scrooge.
+
+'Ding, dong!'
+
+'A quarter to it.' said Scrooge.
+
+'Ding, dong!'
+
+'The hour itself,' said Scrooge triumphantly, 'and nothing else!'
+
+He spoke before the hour bell sounded, which it now did with a deep,
+dull, hollow, melancholy ONE. Light flashed up in the room upon the
+instant, and the curtains of his bed were drawn.
+
+The curtains of his bed were drawn aside, I tell you, by a hand. Not
+the curtains at his feet, nor the curtains at his back, but those to
+which his face was addressed. The curtains of his bed were drawn aside;
+and Scrooge, starting up into a half-recumbent attitude, found himself
+face to face with the unearthly visitor who drew them: as close to it as
+I am now to you, and I am standing in the spirit at your elbow.
+
+It was a strange figure--like a child; yet not so like a child as like
+an old man, viewed through some supernatural medium, which gave him the
+appearance of having receded from the view, and being diminished to a
+child's proportions. Its hair, which hung about its neck and down its
+back, was white, as if with age; and yet the face had not a wrinkle in
+it, and the tenderest bloom was on the skin. The arms were very long and
+muscular; the hands the same, as if its hold were of uncommon strength.
+Its legs and feet, most delicately formed, were, like those upper
+members, bare. It wore a tunic of the purest white; and round its waist
+was bound a lustrous belt, the sheen of which was beautiful. It held a
+branch of fresh green holly in its hand; and, in singular contradiction
+of that wintry emblem, had its dress trimmed with summer flowers. But
+the strangest thing about it was, that from the crown of its head there
+sprang a bright clear jet of light, by which all this was visible; and
+which was doubtless the occasion of its using, in its duller moments, a
+great extinguisher for a cap, which it now held under its arm.
+
+Even this, though, when Scrooge looked at it with increasing steadiness,
+was _not_ its strangest quality. For, as its belt sparkled and
+glittered, now in one part and now in another, and what was light one
+instant at another time was dark, so the figure itself fluctuated in its
+distinctness; being now a thing with one arm, now with one leg, now with
+twenty legs, now a pair of legs without a head, now a head without a
+body: of which dissolving parts no outline would be visible in the dense
+gloom wherein they melted away. And, in the very wonder of this, it
+would be itself again; distinct and clear as ever.
+
+'Are you the Spirit, sir, whose coming was foretold to me?' asked
+Scrooge.
+
+'I am!'
+
+The voice was soft and gentle. Singularly low, as if, instead of being
+so close behind him, it were at a distance.
+
+'Who and what are you?' Scrooge demanded.
+
+'I am the Ghost of Christmas Past.'
+
+'Long Past?' inquired Scrooge, observant of its dwarfish stature.
+
+'No. Your past.'
+
+Perhaps Scrooge could not have told anybody why, if anybody could have
+asked him; but he had a special desire to see the Spirit in his cap,
+and begged him to be covered.
+
+'What!' exclaimed the Ghost, 'would you so soon put out, with worldly
+hands, the light I give? Is it not enough that you are one of those
+whose passions made this cap, and force me through whole trains of years
+to wear it low upon my brow?'
+
+Scrooge reverently disclaimed all intention to offend or any knowledge
+of having wilfully 'bonneted' the Spirit at any period of his life. He
+then made bold to inquire what business brought him there.
+
+'Your welfare!' said the Ghost.
+
+Scrooge expressed himself much obliged, but could not help thinking that
+a night of unbroken rest would have been more conducive to that end. The
+Spirit must have heard him thinking, for it said immediately--
+
+'Your reclamation, then. Take heed!'
+
+It put out its strong hand as it spoke, and clasped him gently by the
+arm.
+
+'Rise! and walk with me!'
+
+It would have been in vain for Scrooge to plead that the weather and the
+hour were not adapted to pedestrian purposes; that bed was warm, and the
+thermometer a long way below freezing; that he was clad but lightly in
+his slippers, dressing-gown, and nightcap; and that he had a cold upon
+him at that time. The grasp, though gentle as a woman's hand, was not
+to be resisted. He rose; but, finding that the Spirit made towards the
+window, clasped its robe in supplication.
+
+'I am a mortal,' Scrooge remonstrated, 'and liable to fall.'
+
+'Bear but a touch of my hand _there_,' said the Spirit, laying it upon
+his heart, 'and you shall be upheld in more than this!'
+
+As the words were spoken, they passed through the wall, and stood upon
+an open country road, with fields on either hand. The city had entirely
+vanished. Not a vestige of it was to be seen. The darkness and the mist
+had vanished with it, for it was a clear, cold, winter day, with snow
+upon the ground.
+
+'Good Heaven!' said Scrooge, clasping his hands together, as he looked
+about him. 'I was bred in this place. I was a boy here!'
+
+The Spirit gazed upon him mildly. Its gentle touch, though it had been
+light and instantaneous, appeared still present to the old man's sense
+of feeling. He was conscious of a thousand odours floating in the air,
+each one connected with a thousand thoughts, and hopes, and joys, and
+cares long, long forgotten!
+
+'Your lip is trembling,' said the Ghost. 'And what is that upon your
+cheek?'
+
+Scrooge muttered, with an unusual catching in his voice, that it was a
+pimple; and begged the Ghost to lead him where he would.
+
+'You recollect the way?' inquired the Spirit.
+
+'Remember it!' cried Scrooge with fervour; 'I could walk it blindfold.'
+
+'Strange to have forgotten it for so many years!' observed the Ghost.
+'Let us go on.'
+
+They walked along the road, Scrooge recognising every gate, and post,
+and tree, until a little market-town appeared in the distance, with its
+bridge, its church, and winding river. Some shaggy ponies now were seen
+trotting towards them with boys upon their backs, who called to other
+boys in country gigs and carts, driven by farmers. All these boys were
+in great spirits, and shouted to each other, until the broad fields were
+so full of merry music, that the crisp air laughed to hear it.
+
+'These are but shadows of the things that have been,' said the Ghost.
+'They have no consciousness of us.'
+
+The jocund travellers came on; and as they came, Scrooge knew and named
+them every one. Why was he rejoiced beyond all bounds to see them? Why
+did his cold eye glisten, and his heart leap up as they went past? Why
+was he filled with gladness when he heard them give each other Merry
+Christmas, as they parted at cross-roads and by-ways for their several
+homes? What was merry Christmas to Scrooge? Out upon merry Christmas!
+What good had it ever done to him?
+
+'The school is not quite deserted,' said the Ghost. 'A solitary child,
+neglected by his friends, is left there still.'
+
+Scrooge said he knew it. And he sobbed.
+
+They left the high-road by a well-remembered lane and soon approached a
+mansion of dull red brick, with a little weather-cock surmounted cupola
+on the roof, and a bell hanging in it. It was a large house, but one of
+broken fortunes; for the spacious offices were little used, their walls
+were damp and mossy, their windows broken, and their gates decayed.
+Fowls clucked and strutted in the stables; and the coach-houses and
+sheds were overrun with grass. Nor was it more retentive of its ancient
+state within; for, entering the dreary hall, and glancing through the
+open doors of many rooms, they found them poorly furnished, cold, and
+vast. There was an earthy savour in the air, a chilly bareness in the
+place, which associated itself somehow with too much getting up by
+candle light and not too much to eat.
+
+They went, the Ghost and Scrooge, across the hall, to a door at the back
+of the house. It opened before them, and disclosed a long, bare,
+melancholy room, made barer still by lines of plain deal forms and
+desks. At one of these a lonely boy was reading near a feeble fire; and
+Scrooge sat down upon a form, and wept to see his poor forgotten self as
+he had used to be.
+
+Not a latent echo in the house, not a squeak and scuffle from the mice
+behind the panelling, not a drip from the half-thawed waterspout in the
+dull yard behind, not a sigh among the leafless boughs of one despondent
+poplar, not the idle swinging of an empty storehouse door, no, not a
+clicking in the fire, but fell upon the heart of Scrooge with softening
+influence, and gave a freer passage to his tears.
+
+The Spirit touched him on the arm, and pointed to his younger self,
+intent upon his reading. Suddenly a man in foreign garments, wonderfully
+real and distinct to look at, stood outside the window, with an axe
+stuck in his belt, and leading by the bridle an ass laden with wood.
+
+'Why, it's Ali Baba!' Scrooge exclaimed in ecstasy. 'It's dear old
+honest Ali Baba! Yes, yes, I know. One Christmas-time, when yonder
+solitary child was left here all alone, he _did_ come, for the first
+time, just like that. Poor boy! And Valentine,' said Scrooge, 'and his
+wild brother, Orson; there they go! And what's his name, who was put
+down in his drawers, asleep, at the gate of Damascus; don't you see him?
+And the Sultan's Groom turned upside down by the Genii; there he is upon
+his head! Serve him right! I'm glad of it. What business had he to be
+married to the Princess?'
+
+To hear Scrooge expending all the earnestness of his nature on such
+subjects, in a most extraordinary voice between laughing and crying; and
+to see his heightened and excited face; would have been a surprise to
+his business friends in the City, indeed.
+
+'There's the Parrot!' cried Scrooge. 'Green body and yellow tail, with a
+thing like a lettuce growing out of the top of his head; there he is!
+Poor Robin Crusoe he called him, when he came home again after sailing
+round the island. "Poor Robin Crusoe, where have you been, Robin
+Crusoe?" The man thought he was dreaming, but he wasn't. It was the
+Parrot, you know. There goes Friday, running for his life to the little
+creek! Halloa! Hoop! Halloo!'
+
+Then, with a rapidity of transition very foreign to his usual character,
+he said, in pity for his former self, 'Poor boy!' and cried again.
+
+'I wish,' Scrooge muttered, putting his hand in his pocket, and looking
+about him, after drying his eyes with his cuff; 'but it's too late now.'
+
+'What is the matter?' asked the Spirit.
+
+'Nothing,' said Scrooge. 'Nothing. There was a boy singing a Christmas
+carol at my door last night. I should like to have given him something:
+that's all.'
+
+The Ghost smiled thoughtfully, and waved its hand, saying as it did so,
+'Let us see another Christmas!'
+
+Scrooge's former self grew larger at the words, and the room became a
+little darker and more dirty. The panels shrunk, the windows cracked;
+fragments of plaster fell out of the ceiling, and the naked laths were
+shown instead; but how all this was brought about Scrooge knew no more
+than you do. He only knew that it was quite correct; that everything had
+happened so; that there he was, alone again, when all the other boys had
+gone home for the jolly holidays.
+
+He was not reading now, but walking up and down despairingly. Scrooge
+looked at the Ghost, and, with a mournful shaking of his head, glanced
+anxiously towards the door.
+
+It opened; and a little girl, much younger than the boy, came darting
+in, and, putting her arms about his neck, and often kissing him,
+addressed him as her 'dear, dear brother.'
+
+'I have come to bring you home, dear brother!' said the child, clapping
+her tiny hands, and bending down to laugh. 'To bring you home, home,
+home!'
+
+'Home, little Fan?' returned the boy.
+
+'Yes!' said the child, brimful of glee. 'Home for good and all. Home for
+ever and ever. Father is so much kinder than he used to be, that home's
+like heaven! He spoke so gently to me one dear night when I was going to
+bed, that I was not afraid to ask him once more if you might come home;
+and he said Yes, you should; and sent me in a coach to bring you. And
+you're to be a man!' said the child, opening her eyes; 'and are never to
+come back here; but first we're to be together all the Christmas long,
+and have the merriest time in all the world.'
+
+'You are quite a woman, little Fan!' exclaimed the boy.
+
+She clapped her hands and laughed, and tried to touch his head; but,
+being too little laughed again, and stood on tiptoe to embrace him. Then
+she began to drag him, in her childish eagerness, towards the door; and
+he, nothing loath to go, accompanied her.
+
+A terrible voice in the hall cried, 'Bring down Master Scrooge's box,
+there!' and in the hall appeared the schoolmaster himself, who glared on
+Master Scrooge with a ferocious condescension, and threw him into a
+dreadful state of mind by shaking hands with him. He then conveyed him
+and his sister into the veriest old well of a shivering best parlour
+that ever was seen, where the maps upon the wall, and the celestial and
+terrestrial globes in the windows, were waxy with cold. Here he produced
+a decanter of curiously light wine, and a block of curiously heavy cake,
+and administered instalments of those dainties to the young people; at
+the same time sending out a meagre servant to offer a glass of
+'something' to the postboy, who answered that he thanked the gentleman,
+but, if it was the same tap as he had tasted before, he had rather not.
+Master Scrooge's trunk being by this time tied on to the top of the
+chaise, the children bade the schoolmaster good-bye right willingly;
+and, getting into it, drove gaily down the garden sweep; the quick
+wheels dashing the hoar-frost and snow from off the dark leaves of the
+evergreens like spray.
+
+
+'Always a delicate creature, whom a breath might have withered,' said
+the Ghost. 'But she had a large heart!'
+
+'So she had,' cried Scrooge. 'You're right. I will not gainsay it,
+Spirit. God forbid!'
+
+'She died a woman,' said the Ghost, 'and had, as I think, children.'
+
+'One child,' Scrooge returned.
+
+'True,' said the Ghost. 'Your nephew!'
+
+Scrooge seemed uneasy in his mind, and answered briefly, 'Yes.'
+
+Although they had but that moment left the school behind them, they were
+now in the busy thoroughfares of a city, where shadowy passengers passed
+and re-passed; where shadowy carts and coaches battled for the way, and
+all the strife and tumult of a real city were. It was made plain enough,
+by the dressing of the shops, that here, too, it was Christmas-time
+again; but it was evening, and the streets were lighted up.
+
+The Ghost stopped at a certain warehouse door, and asked Scrooge if he
+knew it.
+
+'Know it!' said Scrooge. 'Was I apprenticed here?'
+
+They went in. At sight of an old gentleman in a Welsh wig, sitting
+behind such a high desk, that if he had been two inches taller, he must
+have knocked his head against the ceiling, Scrooge cried in great
+excitement--
+
+'Why, it's old Fezziwig! Bless his heart, it's Fezziwig alive again!'
+
+Old Fezziwig laid down his pen, and looked up at the clock, which
+pointed to the hour of seven. He rubbed his hands; adjusted his
+capacious waistcoat; laughed all over himself, from his shoes to his
+organ of benevolence; and called out, in a comfortable, oily, rich, fat,
+jovial voice--
+
+'Yo ho, there! Ebenezer! Dick!'
+
+Scrooge's former self, now grown a young man, came briskly in,
+accompanied by his fellow-'prentice.
+
+'Dick Wilkins, to be sure!' said Scrooge to the Ghost. 'Bless me, yes.
+There he is. He was very much attached to me, was Dick. Poor Dick! Dear,
+dear!'
+
+'Yo ho, my boys!' said Fezziwig. 'No more work to-night. Christmas Eve,
+Dick. Christmas, Ebenezer! Let's have the shutters up,' cried old
+Fezziwig, with a sharp clap of his hands, 'before a man can say Jack
+Robinson!'
+
+You wouldn't believe how those two fellows went at it! They charged into
+the street with the shutters--one, two, three--had 'em up in their
+places--four, five, six--barred 'em and pinned 'em--seven, eight,
+nine--and came back before you could have got to twelve, panting like
+racehorses.
+
+'Hilli-ho!' cried old Fezziwig, skipping down from the high desk with
+wonderful agility. 'Clear away, my lads, and let's have lots of room
+here! Hilli-ho, Dick! Chirrup, Ebenezer!'
+
+Clear away! There was nothing they wouldn't have cleared away, or
+couldn't have cleared away, with old Fezziwig looking on. It was done in
+a minute. Every movable was packed off, as if it were dismissed from
+public life for evermore; the floor was swept and watered, the lamps
+were trimmed, fuel was heaped upon the fire; and the warehouse was as
+snug, and warm, and dry, and bright a ball-room as you would desire to
+see upon a winter's night.
+
+In came a fiddler with a music-book, and went up to the lofty desk, and
+made an orchestra of it, and tuned like fifty stomach-aches. In came
+Mrs. Fezziwig, one vast substantial smile. In came the three Miss
+Fezziwigs, beaming and lovable. In came the six young followers whose
+hearts they broke. In came all the young men and women employed in the
+business. In came the housemaid, with her cousin the baker. In came the
+cook with her brother's particular friend the milkman. In came the boy
+from over the way, who was suspected of not having board enough from his
+master; trying to hide himself behind the girl from next door but one,
+who was proved to have had her ears pulled by her mistress. In they all
+came, one after another; some shyly, some boldly, some gracefully, some
+awkwardly, some pushing, some pulling; in they all came, any how and
+every how. Away they all went, twenty couple at once; hands half round
+and back again the other way; down the middle and up again; round and
+round in various stages of affectionate grouping; old top couple always
+turning up in the wrong place; new top couple starting off again as soon
+as they got there; all top couples at last, and not a bottom one to help
+them! When this result was brought about, old Fezziwig, clapping his
+hands to stop the dance, cried out, 'Well done!' and the fiddler plunged
+his hot face into a pot of porter, especially provided for that purpose.
+But, scorning rest upon his reappearance, he instantly began again,
+though there were no dancers yet, as if the other fiddler had been
+carried home, exhausted, on a shutter, and he were a bran-new man
+resolved to beat him out of sight, or perish.
+
+
+There were more dances, and there were forfeits, and more dances, and
+there was cake, and there was negus, and there was a great piece of Cold
+Roast, and there was a great piece of Cold Boiled, and there were
+mince-pies, and plenty of beer. But the great effect of the evening came
+after the Roast and Boiled, when the fiddler (an artful dog, mind! The
+sort of man who knew his business better than you or I could have told
+it him!) struck up 'Sir Roger de Coverley.' Then old Fezziwig stood
+out to dance with Mrs. Fezziwig. Top couple, too; with a good stiff
+piece of work cut out for them; three or four and twenty pair of
+partners; people who were not to be trifled with; people who would
+dance, and had no notion of walking.
+
+But if they had been twice as many--ah! four times--old Fezziwig would
+have been a match for them, and so would Mrs. Fezziwig. As to _her_, she
+was worthy to be his partner in every sense of the term. If that's not
+high praise, tell me higher, and I'll use it. A positive light appeared
+to issue from Fezziwig's calves. They shone in every part of the dance
+like moons. You couldn't have predicted, at any given time, what would
+become of them next. And when old Fezziwig and Mrs. Fezziwig had gone
+all through the dance; advance and retire, both hands to your partner,
+bow and curtsy, cork-screw, thread-the-needle, and back again to your
+place: Fezziwig 'cut'--cut so deftly, that he appeared to wink with his
+legs, and came upon his feet again without a stagger.
+
+When the clock struck eleven, this domestic ball broke up. Mr. and Mrs.
+Fezziwig took their stations, one on either side the door, and, shaking
+hands with every person individually as he or she went out, wished him
+or her a Merry Christmas. When everybody had retired but the two
+'prentices, they did the same to them; and thus the cheerful voices died
+away, and the lads were left to their beds; which were under a counter
+in the back-shop.
+
+During the whole of this time Scrooge had acted like a man out of his
+wits. His heart and soul were in the scene, and with his former self. He
+corroborated everything, remembered everything, enjoyed everything, and
+underwent the strangest agitation. It was not until now, when the bright
+faces of his former self and Dick were turned from them, that he
+remembered the Ghost, and became conscious that it was looking full upon
+him, while the light upon its head burnt very clear.
+
+'A small matter,' said the Ghost, 'to make these silly folks so full of
+gratitude.'
+
+'Small!' echoed Scrooge.
+
+The Spirit signed to him to listen to the two apprentices, who were
+pouring out their hearts in praise of Fezziwig; and when he had done so,
+said:
+
+'Why! Is it not? He has spent but a few pounds of your mortal money:
+three or four, perhaps. Is that so much that he deserves this praise?'
+
+'It isn't that,' said Scrooge, heated by the remark, and speaking
+unconsciously like his former, not his latter self. 'It isn't that,
+Spirit. He has the power to render us happy or unhappy; to make our
+service light or burdensome; a pleasure or a toil. Say that his power
+lies in words and looks; in things so slight and insignificant that it
+is impossible to add and count 'em up: what then? The happiness he gives
+is quite as great as if it cost a fortune.'
+
+He felt the Spirit's glance, and stopped.
+
+'What is the matter?' asked the Ghost.
+
+'Nothing particular,' said Scrooge.
+
+'Something, I think?' the Ghost insisted.
+
+'No,' said Scrooge, 'no. I should like to be able to say a word or two
+to my clerk just now. That's all.'
+
+His former self turned down the lamps as he gave utterance to the wish;
+and Scrooge and the Ghost again stood side by side in the open air.
+
+'My time grows short,' observed the Spirit. 'Quick!'
+
+This was not addressed to Scrooge, or to any one whom he could see, but
+it produced an immediate effect. For again Scrooge saw himself. He was
+older now; a man in the prime of life. His face had not the harsh and
+rigid lines of later years; but it had begun to wear the signs of care
+and avarice. There was an eager, greedy, restless motion in the eye,
+which showed the passion that had taken root, and where the shadow of
+the growing tree would fall.
+
+He was not alone, but sat by the side of a fair young girl in a mourning
+dress: in whose eyes there were tears, which sparkled in the light that
+shone out of the Ghost of Christmas Past.
+
+'It matters little,' she said softly. 'To you, very little. Another idol
+has displaced me; and, if it can cheer and comfort you in time to come
+as I would have tried to do, I have no just cause to grieve.'
+
+'What Idol has displaced you?' he rejoined.
+
+'A golden one.'
+
+'This is the even-handed dealing of the world!' he said. 'There is
+nothing on which it is so hard as poverty; and there is nothing it
+professes to condemn with such severity as the pursuit of wealth!'
+
+'You fear the world too much,' she answered gently. 'All your other
+hopes have merged into the hope of being beyond the chance of its sordid
+reproach. I have seen your nobler aspirations fall off one by one, until
+the master passion, Gain, engrosses you. Have I not?'
+
+'What then?' he retorted. 'Even if I have grown so much wiser, what
+then? I am not changed towards you.'
+
+She shook her head.
+
+'Am I?'
+
+'Our contract is an old one. It was made when we were both poor, and
+content to be so, until, in good season, we could improve our worldly
+fortune by our patient industry. You _are_ changed. When it was made you
+were another man.'
+
+'I was a boy,' he said impatiently.
+
+'Your own feeling tells you that you were not what you are,' she
+returned. 'I am. That which promised happiness when we were one in heart
+is fraught with misery now that we are two. How often and how keenly I
+have thought of this I will not say. It is enough that I _have_ thought
+of it, and can release you.'
+
+'Have I ever sought release?'
+
+'In words. No. Never.'
+
+'In what, then?'
+
+'In a changed nature; in an altered spirit; in another atmosphere of
+life; another Hope as its great end. In everything that made my love of
+any worth or value in your sight. If this had never been between us,'
+said the girl, looking mildly, but with steadiness, upon him; 'tell me,
+would you seek me out and try to win me now? Ah, no!'
+
+He seemed to yield to the justice of this supposition in spite of
+himself. But he said, with a struggle, 'You think not.'
+
+'I would gladly think otherwise if I could,' she answered. 'Heaven
+knows! When _I_ have learned a Truth like this, I know how strong and
+irresistible it must be. But if you were free to-day, to-morrow,
+yesterday, can even I believe that you would choose a dowerless
+girl--you who, in your very confidence with her, weigh everything by
+Gain: or, choosing her, if for a moment you were false enough to your
+one guiding principle to do so, do I not know that your repentance and
+regret would surely follow? I do; and I release you. With a full heart,
+for the love of him you once were.'
+
+
+He was about to speak; but, with her head turned from him, she resumed:
+
+'You may--the memory of what is past half makes me hope you will--have
+pain in this. A very, very brief time, and you will dismiss the
+recollection of it gladly, as an unprofitable dream, from which it
+happened well that you awoke. May you be happy in the life you have
+chosen!'
+
+She left him, and they parted.
+
+'Spirit!' said Scrooge, 'show me no more! Conduct me home. Why do you
+delight to torture me?'
+
+'One shadow more!' exclaimed the Ghost.
+
+'No more!' cried Scrooge. 'No more! I don't wish to see it. Show me no
+more!'
+
+But the relentless Ghost pinioned him in both his arms, and forced him
+to observe what happened next.
+
+They were in another scene and place; a room, not very large or
+handsome, but full of comfort. Near to the winter fire sat a beautiful
+young girl, so like that last that Scrooge believed it was the same,
+until he saw _her_, now a comely matron, sitting opposite her daughter.
+The noise in this room was perfectly tumultuous, for there were more
+children there than Scrooge in his agitated state of mind could count;
+and, unlike the celebrated herd in the poem, they were not forty
+children conducting themselves like one, but every child was conducting
+itself like forty. The consequences were uproarious beyond belief; but
+no one seemed to care; on the contrary, the mother and daughter laughed
+heartily, and enjoyed it very much; and the latter, soon beginning to
+mingle in the sports, got pillaged by the young brigands most
+ruthlessly. What would I not have given to be one of them! Though I
+never could have been so rude, no, no! I wouldn't for the wealth of all
+the world have crushed that braided hair, and torn it down; and for the
+precious little shoe, I wouldn't have plucked it off, God bless my soul!
+to save my life. As to measuring her waist in sport, as they did, bold
+young brood, I couldn't have done it; I should have expected my arm to
+have grown round it for a punishment, and never come straight again. And
+yet I should have dearly liked, I own, to have touched her lips; to have
+questioned her, that she might have opened them; to have looked upon the
+lashes of her downcast eyes, and never raised a blush; to have let loose
+waves of hair, an inch of which would be a keepsake beyond price: in
+short, I should have liked, I do confess, to have had the lightest
+license of a child, and yet to have been man enough to know its value.
+
+
+But now a knocking at the door was heard, and such a rush immediately
+ensued that she, with laughing face and plundered dress, was borne
+towards it the centre of a flushed and boisterous group, just in time to
+greet the father, who came home attended by a man laden with Christmas
+toys and presents. Then the shouting and the struggling, and the
+onslaught that was made on the defenceless porter! The scaling him, with
+chairs for ladders, to dive into his pockets, despoil him of
+brown-paper parcels, hold on tight by his cravat, hug him round his
+neck, pummel his back, and kick his legs in irrepressible affection! The
+shouts of wonder and delight with which the development of every package
+was received! The terrible announcement that the baby had been taken in
+the act of putting a doll's frying pan into his mouth, and was more than
+suspected of having swallowed a fictitious turkey, glued on a wooden
+platter! The immense relief of finding this a false alarm! The joy, and
+gratitude, and ecstasy! They are all indescribable alike. It is enough
+that, by degrees, the children and their emotions got out of the
+parlour, and, by one stair at a time, up to the top of the house, where
+they went to bed, and so subsided.
+
+And now Scrooge looked on more attentively than ever, when the master of
+the house, having his daughter leaning fondly on him, sat down with her
+and her mother at his own fireside; and when he thought that such
+another creature, quite as graceful and as full of promise, might have
+called him father, and been a spring-time in the haggard winter of his
+life, his sight grew very dim indeed.
+
+'Belle,' said the husband, turning to his wife with a smile, 'I saw an
+old friend of yours this afternoon.'
+
+'Who was it?'
+
+'Guess!'
+
+'How can I? Tut, don't I know?' she added in the same breath, laughing
+as he laughed. 'Mr. Scrooge.'
+
+'Mr. Scrooge it was. I passed his office window; and as it was not shut
+up, and he had a candle inside, I could scarcely help seeing him. His
+partner lies upon the point of death, I hear; and there he sat alone.
+Quite alone in the world, I do believe.'
+
+'Spirit!' said Scrooge in a broken voice, 'remove me from this place.'
+
+'I told you these were shadows of the things that have been,' said the
+Ghost. 'That they are what they are do not blame me!'
+
+'Remove me!' Scrooge exclaimed, 'I cannot bear it!'
+
+He turned upon the Ghost, and seeing that it looked upon him with a
+face, in which in some strange way there were fragments of all the faces
+it had shown him, wrestled with it.
+
+'Leave me! Take me back. Haunt me no longer!'
+
+In the struggle, if that can be called a struggle in which the Ghost
+with no visible resistance on its own part was undisturbed by any effort
+of its adversary, Scrooge observed that its light was burning high and
+bright; and dimly connecting that with its influence over him, he seized
+the extinguisher-cap, and by a sudden action pressed it down upon its
+head.
+
+
+The Spirit dropped beneath it, so that the extinguisher covered its
+whole form; but though Scrooge pressed it down with all his force, he
+could not hide the light, which streamed from under it, in an unbroken
+flood upon the ground.
+
+He was conscious of being exhausted, and overcome by an irresistible
+drowsiness; and, further, of being in his own bedroom. He gave the cap a
+parting squeeze, in which his hand relaxed; and had barely time to reel
+to bed, before he sank into a heavy sleep.
+
+
+[1]: https://www.gutenberg.org/ebooks/24022

--- a/__tests__/streamdown.test.ts
+++ b/__tests__/streamdown.test.ts
@@ -86,4 +86,23 @@ test('transform options are applied', () => {
   assert.is(result.readableEncoding, 'utf8')
 })
 
+
+test('links in large documents are applied', () => {
+  const source = createReadStream(`${process.cwd()}/__tests__/fixtures/large_document_test.md`)
+
+  const md = streamdown()
+
+  let output = ''
+
+  source
+    .pipe(md)
+    .on('data', (d) => {
+      if (d) output += d.toString()
+    })
+    .on('end', () => {
+      assert.is(output.split('\n')[0].trim(), '<p>Hello <a href="https://www.gutenberg.org/ebooks/24022">link</a></p>')
+    })
+
+})
+
 test.run()


### PR DESCRIPTION
Markdown is not exactly a streamable format. Link (and other) references may not be in the same chunk you pass to `marked()`. This test demonstrates that a link at the top of the document, and it's actual value at the bottom do not result in the correct HTML.



To verify the HTML _would_ be correct, you can manually cut the line at the bottom `[1]: https://....` and paste it near the top of the document, run the test, it will pass. It's as soon as the link definition and it's reference result in different chunks in the stream that the result HTML will break.